### PR TITLE
nodeinfoのsoftwareをareionskeyに変更

### DIFF
--- a/src/server/nodeinfo.ts
+++ b/src/server/nodeinfo.ts
@@ -36,7 +36,7 @@ const nodeinfo2 = async () => {
 
 	return {
 		software: {
-			name: 'misskey',
+			name: 'areionskey',
 			version: config.version,
 			repository: meta.repositoryUrl,
 		},


### PR DESCRIPTION
nodeinfoのソフトウェア名は連合先にも反映されるので`package.json`と同様のものに変更しておくことを推奨します