### PR TITLE
feat: ElasticSearchなしで検索可能 Resolves #12

### DIFF
--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -1,11 +1,13 @@
 import $ from 'cafy';
 import es from '../../../../db/elasticsearch';
 import define from '../../define';
-import { ApiError } from '../../error';
 import { Notes } from '../../../../models';
 import { In } from 'typeorm';
 import { ID } from '../../../../misc/cafy-id';
 import config from '../../../../config';
+import { makePaginationQuery } from '../../common/make-pagination-query';
+import { generateVisibilityQuery } from '../../common/generate-visibility-query';
+import { generateMuteQuery } from '../../common/generate-mute-query';
 
 export const meta = {
 	desc: {
@@ -22,14 +24,17 @@ export const meta = {
 			validator: $.str
 		},
 
+		sinceId: {
+			validator: $.optional.type(ID),
+		},
+
+		untilId: {
+			validator: $.optional.type(ID),
+		},
+
 		limit: {
 			validator: $.optional.num.range(1, 100),
 			default: 10
-		},
-
-		offset: {
-			validator: $.optional.num.min(0),
-			default: 0
 		},
 
 		host: {
@@ -54,74 +59,80 @@ export const meta = {
 	},
 
 	errors: {
-		searchingNotAvailable: {
-			message: 'Searching not available.',
-			code: 'SEARCHING_NOT_AVAILABLE',
-			id: '7ee9c119-16a1-479f-a6fd-6fab00ed946f'
-		}
 	}
 };
 
 export default define(meta, async (ps, me) => {
-	if (es == null) throw new ApiError(meta.errors.searchingNotAvailable);
+	if (es == null) {
+		const query = makePaginationQuery(Notes.createQueryBuilder('note'), ps.sinceId, ps.untilId)
+			.andWhere('note.text ILIKE :q', { q: `%${ps.query}%` })
+			.leftJoinAndSelect('note.user', 'user');
 
-	const userQuery = ps.userId != null ? [{
-		term: {
-			userId: ps.userId
-		}
-	}] : [];
+		generateVisibilityQuery(query, me);
+		if (me) generateMuteQuery(query, me);
 
-	const hostQuery = ps.userId == null ?
-		ps.host === null ? [{
-			bool: {
-				must_not: {
-					exists: {
-						field: 'userHost'
+		const notes = await query.take(ps.limit!).getMany();
+
+		return await Notes.packMany(notes, me);
+	} else {
+		const userQuery = ps.userId != null ? [{
+			term: {
+				userId: ps.userId
+			}
+		}] : [];
+
+		const hostQuery = ps.userId == null ?
+			ps.host === null ? [{
+				bool: {
+					must_not: {
+						exists: {
+							field: 'userHost'
+						}
 					}
 				}
-			}
-		}] : ps.host !== undefined ? [{
-			term: {
-				userHost: ps.host
-			}
-		}] : []
-	: [];
-
-	const result = await es.search({
-		index: config.elasticsearch.index || 'misskey_note',
-		body: {
-			size: ps.limit!,
-			from: ps.offset,
-			query: {
-				bool: {
-					must: [{
-						simple_query_string: {
-							fields: ['text'],
-							query: ps.query.toLowerCase(),
-							default_operator: 'and'
-						},
-					}, ...hostQuery, ...userQuery]
+			}] : ps.host !== undefined ? [{
+				term: {
+					userHost: ps.host
 				}
+			}] : []
+		: [];
+
+		const result = await es.search({
+			index: config.elasticsearch.index || 'misskey_note',
+			body: {
+				size: ps.limit!,
+				from: ps.offset,
+				query: {
+					bool: {
+						must: [{
+							simple_query_string: {
+								fields: ['text'],
+								query: ps.query.toLowerCase(),
+								default_operator: 'and'
+							},
+						}, ...hostQuery, ...userQuery]
+					}
+				},
+				sort: [{
+					_doc: 'desc'
+				}]
+			}
+		});
+
+		const hits = result.body.hits.hits.map((hit: any) => hit._id);
+
+		if (hits.length === 0) return [];
+
+		// Fetch found notes
+		const notes = await Notes.find({
+			where: {
+				id: In(hits)
 			},
-			sort: [{
-				_doc: 'desc'
-			}]
-		}
-	});
+			order: {
+				id: -1
+			}
+		});
 
-	const hits = result.body.hits.hits.map((hit: any) => hit._id);
-
-	if (hits.length === 0) return [];
-
-	// Fetch found notes
-	const notes = await Notes.find({
-		where: {
-			id: In(hits)
-		},
-		order: {
-			id: -1
-		}
-	});
-
-	return await Notes.packMany(notes, me);
+		return await Notes.packMany(notes, me);
+	}
 });


### PR DESCRIPTION
## Summary
Make able to search without ElasticSearch or other extensions
ElasticSearchや他の拡張機能などを使用せずに検索が動くようにした

## 💡 Reason
Resolves #12

## Test
Node.js CI, docker CI, E2E test has been passed