### PR TITLE
Require follow request if follower is silenced

### DIFF
--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -123,8 +123,13 @@ export default async function(follower: User, followee: User, requestId?: string
 	// フォロワーがBotであり、フォロー対象がBotからのフォローに慎重である or
 	// フォロワーがリモートユーザーであり、フォロー対象がリモートからのフォローに慎重である or
 	// フォロワーがローカルユーザーであり、フォロー対象がリモートユーザーである
+	// フォロワーがサイレンスされている
 	// 上記のいずれかに当てはまる場合はすぐフォローせずにフォローリクエストを発行しておく
-	if (followee.isLocked || (followeeProfile.carefulBot && follower.isBot) || (followeeProfile.carefulRemote && Users.isRemoteUser(follower)) || (Users.isLocalUser(follower) && Users.isRemoteUser(followee))) {
+	if (followee.isLocked
+		|| (followeeProfile.carefulBot && follower.isBot)
+		|| (followeeProfile.carefulRemote && Users.isRemoteUser(follower))
+		|| (Users.isLocalUser(follower) && Users.isRemoteUser(followee))
+		|| follower.isSilenced) {
 		let autoAccept = false;
 
 		// 鍵アカウントであっても、既にフォローされていた場合はスルー


### PR DESCRIPTION
## 💡 Reason

サイレンスの効果がPublic投稿と通知を抑制するだけってのは機能不足感がある
Mastodonと同じようにフォローリクエストを発行するようにするべき

