### PR TITLE
Fix: Fix: admin - access permission

### DIFF
--- a/src/client/app/admin/views/index.vue
+++ b/src/client/app/admin/views/index.vue
@@ -135,7 +135,9 @@ export default Vue.extend({
 			return this.$store.state.i;
 		},
 		isModerator() {
-			return this.i.isAdmin || this.i.isModerator;
+			if (this.i) {
+				return this.i.isAdmin || this.i.isModerator;
+			}
 		}
 	}
 });


### PR DESCRIPTION
## 💡 Reason
非ログイン状態でアクセスすると`this.i`がないって怒られるんです
<!-- Tell us why the idea came up -->
