### PR TITLE
Add: Able to change desktop/mobile mode on top

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -86,6 +86,8 @@ common:
   explore: "Explore"
   following: "Following"
   followers: "Followers"
+  desktop-mode: 'Desktop mode'
+  mobile-mode: 'Mobile mode'
   favorites: "Bookmarks"
   flush: "Clear cache"
   permissions:

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -91,6 +91,8 @@ common:
   explore: "みつける"
   following: "フォロー中"
   followers: "フォロワー"
+  desktop-mode: 'デスクトップ版'
+  mobile-mode: 'モバイル版'
   favorites: "ブックマーク"
   flush: "キャッシュをクリア"
 

--- a/src/client/app/boot.js
+++ b/src/client/app/boot.js
@@ -89,13 +89,20 @@
 	// Detect the user agent
 	const ua = navigator.userAgent.toLowerCase();
 	let isMobile = /mobile|iphone|ipad|android/.test(ua) || window.innerWidth < 576;
-	if (settings && settings.device.appTypeForce) {
-		if (settings.device.appTypeForce === 'mobile') {
+  if (settings && settings.device.appType) {
+		if (settings.device.appType === 'mobile') {
 			isMobile = true;
-		} else if (settings.device.appTypeForce === 'desktop') {
+		} else if (settings.device.appType === 'desktop') {
 			isMobile = false;
 		}
 	}
+  if (settings && settings.device.appTypeForce) {
+    if (settings.device.appTypeForce === 'mobile') {
+      isMobile = true;
+    } else if (settings.device.appTypeForce === 'desktop') {
+      isMobile = false;
+    }
+  }
 
 	// Get the <head> element
 	const head = document.getElementsByTagName('head')[0];

--- a/src/client/app/desktop/views/components/ui.header.account.vue
+++ b/src/client/app/desktop/views/components/ui.header.account.vue
@@ -87,6 +87,12 @@
 						<template v-else><span>{{ $t('@.deck') }}</span><i><fa :icon="faColumns"/></i></template>
 					</p>
 				</li>
+				<li v-if="$store.state.device.appTypeForce == 'auto'" @click="toggleAppType">
+					<p>
+						<template v-if="$root.isMobile"><span>{{ $t('@.desktop-mode') }}</span><i><fa :icon="faDesktop"/></i></template>
+						<template v-else><span>{{ $t('@.mobile-mode') }}</span><i><fa :icon="faMobileAlt" style="margin-right: 3px"/></i></template>
+					</p>
+				</li>
 				<li @click="dark">
 					<p>
 						<span>{{ $store.state.device.darkmode ? $t('@.turn-off-darkmode') : $t('@.turn-on-darkmode') }}</span>
@@ -113,7 +119,7 @@ import i18n from '../../../i18n';
 // import MkSettingsWindow from './settings-window.vue';
 import MkDriveWindow from './drive-window.vue';
 import contains from '../../../common/scripts/contains';
-import { faHome, faColumns, faUsers, faDoorOpen } from '@fortawesome/free-solid-svg-icons';
+import { faHome, faColumns, faUsers, faDoorOpen, faDesktop, faMobileAlt } from '@fortawesome/free-solid-svg-icons';
 import { faMoon, faSun, faStickyNote } from '@fortawesome/free-regular-svg-icons';
 
 export default Vue.extend({
@@ -121,7 +127,7 @@ export default Vue.extend({
 	data() {
 		return {
 			isOpen: false,
-			faHome, faColumns, faMoon, faSun, faStickyNote, faUsers, faDoorOpen
+			faHome, faColumns, faMoon, faSun, faStickyNote, faUsers, faDoorOpen, faDesktop, faMobileAlt
 		};
 	},
 	computed: {
@@ -167,6 +173,10 @@ export default Vue.extend({
 				key: 'darkmode',
 				value: !this.$store.state.device.darkmode
 			});
+		},
+		toggleAppType() {
+			this.$store.commit('device/set', { key: 'appType', value: this.$root.isMobile ? 'desktop' : 'mobile' });
+			location.replace('/');
 		},
 		toggleDeckMode() {
 			this.$store.commit('device/set', { key: 'deckMode', value: !this.$store.state.device.inDeckMode });

--- a/src/client/app/mobile/views/components/ui.nav.vue
+++ b/src/client/app/mobile/views/components/ui.nav.vue
@@ -39,6 +39,10 @@
 					</ul>
 					<ul>
 						<li @click="toggleDeckMode"><p><i><fa :icon="$store.state.device.inDeckMode ? faHome : faColumns" fixed-width/></i><span>{{ $store.state.device.inDeckMode ? $t('@.home') : $t('@.deck') }}</span></p></li>
+						<li v-if="$store.state.device.appTypeForce == 'auto'" @click="toggleAppType">
+							<p><i><fa :icon="$root.isMobile ? faDesktop : faMobileAlt" fixed-width/></i>
+							<span>{{ $root.isMobile ? $t('@.desktop-mode') : $t('@.mobile-mode') }}</span></p>
+						</li>
 						<li @click="dark"><p><i><fa :icon="$store.state.device.darkmode ? faSun : faMoon" fixed-width/></i><span>{{ $store.state.device.darkmode ? $t('@.turn-off-darkmode') : $t('@.turn-on-darkmode') }}</span></p></li>
 					</ul>
 				</div>
@@ -67,7 +71,7 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import { lang, version, codename } from '../../../config';
-import { faNewspaper, faHashtag, faHome, faColumns, faUsers } from '@fortawesome/free-solid-svg-icons';
+import { faNewspaper, faHashtag, faHome, faColumns, faUsers, faDesktop, faMobileAlt } from '@fortawesome/free-solid-svg-icons';
 import { faMoon, faSun, faStickyNote, faBell } from '@fortawesome/free-regular-svg-icons';
 import { search } from '../../../common/scripts/search';
 
@@ -89,7 +93,7 @@ export default Vue.extend({
 			searching: false,
 			showNotifications: false,
 			version, codename,
-			faNewspaper, faHashtag, faMoon, faSun, faHome, faColumns, faStickyNote, faUsers, faBell,
+			faNewspaper, faHashtag, faMoon, faSun, faHome, faColumns, faStickyNote, faUsers, faBell, faDesktop, faMobileAlt
 		};
 	},
 
@@ -158,6 +162,11 @@ export default Vue.extend({
 				key: 'darkmode',
 				value: !this.$store.state.device.darkmode
 			});
+		},
+
+		toggleAppType() {
+			this.$store.commit('device/set', { key: 'appType', value: this.$root.isMobile ? 'desktop' : 'mobile' });
+			location.replace('/');
 		},
 
 		toggleDeckMode() {

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -89,6 +89,7 @@ const defaultDeviceSettings = {
 	roomUseOrthographicCamera: true,
 	activeEmojiCategoryName: undefined,
 	recentEmojis: [],
+	appType: 'auto',
 };
 
 export default (os: MiOS) => new Vuex.Store({


### PR DESCRIPTION
## 💡 Reason
デスクトップ版とモバイル版を切り替えるのはトップ画面でできないと困る感じがします
一応旧来の設定項目を残しておいて、そちらが設定されているなら優先するようにします