### PR TITLE
管理者がユーザーのアカウントを削除する機能

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1509,6 +1509,8 @@ admin/views/users.vue:
   remote-user-updated: "The information regarding the remote user has been updated."
   delete-all-files: "Delete all files"
   delete-all-files-confirm: "Are you sure that you want to delete all files?"
+  delete-account: "Delete Account"
+  delete-account-confirm: "Are you sure that you want to delete this account?"
   username: "Username"
   host: "Host"
   users:

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1649,6 +1649,8 @@ admin/views/users.vue:
   remote-user-updated: "リモートユーザー情報を更新しました"
   delete-all-files: "すべてのファイルを削除"
   delete-all-files-confirm: "すべてのファイルを削除しますか？"
+  delete-account: "アカウントを削除"
+  delete-account-confirm: "このアカウントを削除しますか？"
   username: "ユーザー名"
   host: "ホスト"
   users:

--- a/src/client/app/admin/views/users.vue
+++ b/src/client/app/admin/views/users.vue
@@ -26,7 +26,7 @@
 						<ui-button @click="unsilenceUser">{{ $t('unmake-silence') }}</ui-button>
 					</ui-horizon-group>
 					<ui-horizon-group>
-						<ui-button @click="suspendUser" :disabled="suspending"><fa :icon="faSnowflake"/> {{ $t('suspend') }}</ui-button>
+						<ui-button @click="suspendUser" :disabled="suspending || user.isModerator || user.isAdmin"><fa :icon="faSnowflake"/> {{ $t('suspend') }}</ui-button>
 						<ui-button @click="unsuspendUser" :disabled="unsuspending">{{ $t('unsuspend') }}</ui-button>
 					</ui-horizon-group>
 					<ui-button @click="deleteAllFiles"><fa :icon="faTrashAlt"/> {{ $t('delete-all-files') }}</ui-button>

--- a/src/client/app/admin/views/users.vue
+++ b/src/client/app/admin/views/users.vue
@@ -30,6 +30,7 @@
 						<ui-button @click="unsuspendUser" :disabled="unsuspending">{{ $t('unsuspend') }}</ui-button>
 					</ui-horizon-group>
 					<ui-button @click="deleteAllFiles"><fa :icon="faTrashAlt"/> {{ $t('delete-all-files') }}</ui-button>
+					<ui-button @click="deleteAccount" :disabled="deleting || user.isModerator || user.isAdmin"><fa :icon="faTrashAlt"/> {{ $t('delete-account') }}</ui-button>
 					<ui-textarea v-if="user" :value="user | json5" readonly tall style="margin-top:16px;"></ui-textarea>
 				</div>
 			</div>
@@ -102,6 +103,7 @@ export default Vue.extend({
 			unverifying: false,
 			suspending: false,
 			unsuspending: false,
+			deleting: false,
 			sort: '+createdAt',
 			state: 'all',
 			origin: 'local',
@@ -407,6 +409,29 @@ export default Vue.extend({
 					text: e.message
 				});
 			});
+		},
+
+		async deleteAccount() {
+			if (!await this.getConfirmed(this.$t('delete-account-confirm'))) return;
+
+			this.deleting = true;
+
+			const process = async () => {
+				await this.$root.api('admin/delete-account', { userId: this.user.id });
+				this.$root.dialog({
+					type: 'success',
+					splash: true
+				});
+			};
+
+			await process().catch(e => {
+				this.$root.dialog({
+					type: 'error',
+					text: e.message
+				});
+			});
+
+			this.deleting = false;
 		},
 
 		async getConfirmed(text: string): Promise<Boolean> {

--- a/src/server/api/endpoints/admin/delete-account.ts
+++ b/src/server/api/endpoints/admin/delete-account.ts
@@ -1,0 +1,68 @@
+import $ from 'cafy';
+import { ID } from '../../../../misc/cafy-id';
+import define from '../../define';
+import { Users } from '../../../../models';
+import { insertModerationLog } from '../../../../services/insert-moderation-log';
+import { doPostSuspend } from '../../../../services/suspend-user';
+import { publishTerminate } from '../../../../services/server-event';
+import { createDeleteAccountJob } from '../../../../queue';
+
+export const meta = {
+	desc: {
+		'ja-JP': '指定したユーザーを削除します。',
+		'en-US': 'Delete a user.'
+	},
+
+	tags: ['admin'],
+
+	requireCredential: true,
+	requireModerator: true,
+
+	params: {
+		userId: {
+			validator: $.type(ID),
+			desc: {
+				'ja-JP': '対象のユーザーID',
+				'en-US': 'The user ID which you want to delete'
+			}
+		},
+	}
+};
+
+export default define(meta, async (ps, me) => {
+	const user = await Users.findOne(ps.userId as string);
+
+	if (user == null) {
+		throw new Error('user not found');
+	}
+
+	if (user.isAdmin) {
+		throw new Error('cannot suspend admin');
+	}
+
+	if (user.isModerator) {
+		throw new Error('cannot suspend moderator');
+	}
+
+	if (user.isDeleted) {
+		return;
+	}
+
+	// 物理削除する前にDelete activityを送信する
+  await doPostSuspend(user).catch(e => {});
+
+	createDeleteAccountJob(user);
+
+	await Users.update(user.id, {
+		isDeleted: true
+	});
+
+	insertModerationLog(me, 'delete', {
+		targetId: user.id,
+	});
+
+	if (Users.isLocalUser(user)) {
+		publishTerminate(user.id);
+	}
+
+});


### PR DESCRIPTION
## 💡 Reason
管理者がユーザーアカウントを削除できるようにする

管理者とモデレータのアカウントを削除することはできない
モデレータか管理者は任意のユーザーを削除することができる
