### PR TITLE
Fix: Update moderator

### DIFF
--- a/src/client/app/admin/views/index.vue
+++ b/src/client/app/admin/views/index.vue
@@ -23,7 +23,7 @@
 				<li><router-link to="/queue" active-class="active"><fa :icon="faTasks" fixed-width/>{{ $t('queue') }}</router-link></li>
 				<li><router-link to="/logs" active-class="active"><fa :icon="faStream" fixed-width/>{{ $t('logs') }}</router-link></li>
 				<li><router-link to="/db" active-class="active"><fa :icon="faDatabase" fixed-width/>{{ $t('db') }}</router-link></li>
-				<li><router-link to="/moderators" active-class="active"><fa :icon="faHeadset" fixed-width/>{{ $t('moderators') }}</router-link></li>
+				<li><router-link to="/moderators" active-class="active" v-if="$store.getters.isAdmin"><fa :icon="faHeadset" fixed-width/>{{ $t('moderators') }}</router-link></li>
 				<li><router-link to="/users" active-class="active"><fa icon="users" fixed-width/>{{ $t('users') }}</router-link></li>
 				<li><router-link to="/drive" active-class="active"><fa icon="cloud" fixed-width/>{{ $t('@.drive') }}</router-link></li>
 				<li><router-link to="/federation" active-class="active"><fa :icon="faGlobe" fixed-width/>{{ $t('federation') }}</router-link></li>

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -107,6 +107,8 @@ export default (os: MiOS) => new Vuex.Store({
 	getters: {
 		isSignedIn: state => state.i != null,
 
+		isAdmin: state => state.i && state.i.isAdmin,
+
 		home: state => state.settings.homeProfiles[state.device.homeProfile],
 
 		mobileHome: state => state.settings.mobileHomeProfiles[state.device.mobileHomeProfile],


### PR DESCRIPTION
## Summary

モデレーターの権限を更新できるのは管理者だけなので、モデレータとしてログインしている場合は管理画面にモデレータ編集画面を出さない
