### PR TITLE
公式・プレミアム・ねこ・ボットアカウントを検索可能

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1535,8 +1535,11 @@ admin/views/users.vue:
       moderator: "Moderator"
       adminOrModerator: "Admin/Moderator"
       verified: "Official Account"
+      premiumed: "Premium Account"
       silenced: "Already silenced"
       suspended: "Suspended"
+      bot: "Bot Account"
+      cat: "Cat Account"
     origin:
       title: "Origin"
       combined: "Local + Remote"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1675,8 +1675,11 @@ admin/views/users.vue:
       moderator: "モデレーター"
       adminOrModerator: "管理者+モデレーター"
       verified: "公式アカウント"
+      premiumed: "プレミアムアカウント"
       silenced: "サイレンス済み"
       suspended: "凍結済み"
+      bot: "ボットアカウント"
+      cat: "ねこアカウント"
     origin:
       title: "オリジン"
       combined: "ローカル+リモート"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1678,8 +1678,8 @@ admin/views/users.vue:
       premiumed: "プレミアムアカウント"
       silenced: "サイレンス済み"
       suspended: "凍結済み"
-      bot: "ボットアカウント"
-      cat: "ねこアカウント"
+      bot: "Bot アカウント"
+      cat: "Cat アカウント"
     origin:
       title: "オリジン"
       combined: "ローカル+リモート"

--- a/src/client/app/admin/views/users.vue
+++ b/src/client/app/admin/views/users.vue
@@ -55,8 +55,11 @@
 					<option value="admin">{{ $t('users.state.admin') }}</option>
 					<option value="moderator">{{ $t('users.state.moderator') }}</option>
 					<option value="verified">{{ $t('users.state.verified') }}</option>
+					<option value="premiumed">{{ $t('users.state.premiumed') }}</option>
 					<option value="silenced">{{ $t('users.state.silenced') }}</option>
 					<option value="suspended">{{ $t('users.state.suspended') }}</option>
+					<option value="cat">{{ $t('users.state.cat') }}</option>
+					<option value="bot">{{ $t('users.state.bot') }}</option>
 				</ui-select>
 				<ui-select v-model="origin">
 					<template #label>{{ $t('users.origin.title') }}</template>

--- a/src/server/api/endpoints/admin/show-users.ts
+++ b/src/server/api/endpoints/admin/show-users.ts
@@ -38,8 +38,12 @@ export const meta = {
 				'admin',
 				'moderator',
 				'adminOrModerator',
+				'verified',
+				'premiumed',
 				'silenced',
 				'suspended',
+				'cat',
+				'bot',
 			]),
 			default: 'all'
 		},
@@ -74,10 +78,12 @@ export default define(meta, async (ps, me) => {
 		case 'moderator': query.where('user.isModerator = TRUE'); break;
 		case 'adminOrModerator': query.where('user.isAdmin = TRUE OR isModerator = TRUE'); break;
 		case 'verified': query.where('user.isVerified = TRUE'); break;
-		case 'premium': query.where('user.isPremium = TRUE'); break;
+		case 'premiumed': query.where('user.isPremium = TRUE'); break;
 		case 'alive': query.where('user.updatedAt > :date', { date: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5) }); break;
 		case 'silenced': query.where('user.isSilenced = TRUE'); break;
 		case 'suspended': query.where('user.isSuspended = TRUE'); break;
+		case 'cat': query.where('user.isCat = TRUE'); break;
+		case 'bot': query.where('user.isBot = TRUE'); break;
 	}
 
 	switch (ps.origin) {

--- a/src/server/api/endpoints/users.ts
+++ b/src/server/api/endpoints/users.ts
@@ -37,6 +37,7 @@ export const meta = {
 				'moderator',
 				'adminOrModerator',
 				'verified',
+				'premiumed',
 				'alive'
 			]),
 			default: 'all'
@@ -71,6 +72,7 @@ export default define(meta, async (ps, me) => {
 		case 'moderator': query.where('user.isModerator = TRUE'); break;
 		case 'adminOrModerator': query.where('user.isAdmin = TRUE OR isModerator = TRUE'); break;
 		case 'verified': query.where('user.isVerified = TRUE'); break;
+		case 'premiumed': query.where('user.isPremium = TRUE'); break;
 		case 'alive': query.where('user.updatedAt > :date', { date: new Date(Date.now() - 1000 * 60 * 60 * 24 * 5) }); break;
 	}
 


### PR DESCRIPTION
管理画面から公式・プレミアム・ねこ・Botアカウントを検索できるように
公式・プレミアムアカウントについてはバグ修正を兼ねてる