### PR TITLE
Add: Explorable アカウントの発見しやすさを追加して連合対応

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -828,6 +828,7 @@ common/views/components/profile-editor.vue:
   careful-remote: "Follower requests from remote require approval"
   auto-accept-followed: "Automatically approve follows from the people you follow"
   avoid-search-index: "Avoid search engine index"
+  is-explorable: "Make account visible in \"Explore\""
   advanced: "Other"
   privacy: "Privacy"
   save: "Save"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -891,6 +891,7 @@ common/views/components/profile-editor.vue:
   careful-remote: "リモートからのフォローだけ承認制にする"
   auto-accept-followed: "フォローしているユーザーからのフォローを自動承認する"
   avoid-search-index: "検索エンジンによるインデックスを拒否する"
+  is-explorable: "アカウントを見つけやすくする"
   advanced: "その他"
   privacy: "プライバシー"
   save: "保存"

--- a/migration/1607353487793-isExplorable.ts
+++ b/migration/1607353487793-isExplorable.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class isExplorable1607353487793 implements MigrationInterface {
+    name = 'isExplorable1607353487793'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD "isExplorable" boolean NOT NULL DEFAULT true`);
+        await queryRunner.query(`COMMENT ON COLUMN "user"."isExplorable" IS 'Whether the User is explorable.'`);
+        await queryRunner.query(`CREATE INDEX "IDX_d5a1b83c7cab66f167e6888188" ON "user" ("isExplorable") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_d5a1b83c7cab66f167e6888188"`);
+        await queryRunner.query(`COMMENT ON COLUMN "user"."isExplorable" IS 'Whether the User is explorable.'`);
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "isExplorable"`);
+    }
+
+}

--- a/src/client/app/common/views/components/settings/profile.vue
+++ b/src/client/app/common/views/components/settings/profile.vue
@@ -100,6 +100,7 @@
 			<ui-switch v-model="carefulRemote" :disabled="isLocked" @change="save(false)">{{ $t('careful-remote') }}</ui-switch>
 			<ui-switch v-model="autoAcceptFollowed" :disabled="!isLocked && !carefulBot && !carefulRemote" @change="save(false)">{{ $t('auto-accept-followed') }}</ui-switch>
 			<ui-switch v-model="avoidSearchIndex" @change="save(false)">{{ $t('avoid-search-index') }}</ui-switch>
+			<ui-switch v-model="isExplorable" @change="save(false)">{{ $t('is-explorable') }}</ui-switch>
 		</div>
 	</section>
 
@@ -186,6 +187,7 @@ export default Vue.extend({
 			carefulRemote: false,
 			autoAcceptFollowed: false,
 			avoidSearchIndex: false,
+			isExplorable: false,
 			saving: false,
 			avatarUploading: false,
 			bannerUploading: false,
@@ -229,6 +231,7 @@ export default Vue.extend({
 		this.carefulRemote = this.$store.state.i.carefulRemote;
 		this.autoAcceptFollowed = this.$store.state.i.autoAcceptFollowed;
 		this.avoidSearchIndex = this.$store.state.i.avoidSearchIndex;
+		this.isExplorable = this.$store.state.i.isExplorable;
 
 		this.fieldName0 = this.$store.state.i.fields[0] ? this.$store.state.i.fields[0].name : null;
 		this.fieldValue0 = this.$store.state.i.fields[0] ? this.$store.state.i.fields[0].value : null;
@@ -311,6 +314,7 @@ export default Vue.extend({
 				carefulRemote: !!this.carefulRemote,
 				autoAcceptFollowed: !!this.autoAcceptFollowed,
 				avoidSearchIndex: !!this.avoidSearchIndex,
+				isExplorable: !!this.isExplorable,
 			}).then(i => {
 				this.saving = false;
 				this.$store.state.i.avatarId = i.avatarId;

--- a/src/models/entities/user.ts
+++ b/src/models/entities/user.ts
@@ -216,6 +216,11 @@ export class User {
 	})
 	public avoidSearchIndex: boolean;
 
+	@Column('boolean', {
+		default: true,
+	})
+	public isExplorable: boolean;
+
 	constructor(data: Partial<User>) {
 		if (data == null) return;
 

--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -227,6 +227,7 @@ export class UserRepository extends Repository<User> {
 				carefulRemote: profile!.carefulRemote,
 				autoAcceptFollowed: profile!.autoAcceptFollowed,
 				isDeleted: user.isDeleted,
+				isExplorable: user.isExplorable,
 				hasUnreadMessagingMessage: this.getHasUnreadMessagingMessage(user.id),
 				hasUnreadNotification: this.getHasUnreadNotification(user.id),
 				pendingReceivedFollowRequestsCount: FollowRequests.count({

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -161,6 +161,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 				lastFetchedAt: new Date(),
 				name: person.name ? truncate(person.name, MAX_NAME_LENGTH) : person.name,
 				isLocked: !!person.manuallyApprovesFollowers,
+				isExplorable: !!person.discoverable,
 				username: person.preferredUsername,
 				usernameLower: person.preferredUsername!.toLowerCase(),
 				host,
@@ -343,6 +344,7 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 		isBot: getApType(object) === 'Service',
 		isCat: (person as any).isCat === true,
 		isLocked: !!person.manuallyApprovesFollowers,
+		isExplorable: !!person.discoverable,
 		movedToUserId: movedTo?.id || null,
 	} as Partial<User>;
 

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -70,6 +70,7 @@ export async function renderPerson(user: ILocalUser) {
 		image: banner ? renderImage(banner) : null,
 		tag,
 		manuallyApprovesFollowers: user.isLocked,
+		discoverable: !!user.isExplorable,
 		publicKey: renderKey(user, keypair, `#main-key`),
 		isCat: user.isCat,
 		attachment: attachment.length ? attachment : undefined,

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -151,6 +151,7 @@ export interface IActor extends IObject {
 	name?: string;
 	preferredUsername?: string;
 	manuallyApprovesFollowers?: boolean;
+	discoverable?: boolean;
 	inbox: string;
 	sharedInbox?: string;	// 後方互換性のため
 	publicKey?: {

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -120,6 +120,13 @@ export const meta = {
 			}
 		},
 
+		isExplorable: {
+			validator: $.optional.bool,
+			desc: {
+				'ja-JP': 'アカウントを見つけやすくするか'
+			}
+		},
+
 		isBot: {
 			validator: $.optional.bool,
 			desc: {
@@ -210,6 +217,7 @@ export default define(meta, async (ps, user, app) => {
 	if (typeof ps.carefulRemote == 'boolean') profileUpdates.carefulRemote = ps.carefulRemote;
 	if (typeof ps.autoAcceptFollowed == 'boolean') profileUpdates.autoAcceptFollowed = ps.autoAcceptFollowed;
 	if (typeof ps.avoidSearchIndex == 'boolean') updates.avoidSearchIndex = ps.avoidSearchIndex;
+	if (typeof ps.isExplorable == 'boolean') updates.isExplorable = ps.isExplorable;
 	if (typeof ps.isCat == 'boolean') updates.isCat = ps.isCat;
 	if (typeof ps.autoWatch == 'boolean') profileUpdates.autoWatch = ps.autoWatch;
 	if (typeof ps.alwaysMarkNsfw == 'boolean') profileUpdates.alwaysMarkNsfw = ps.alwaysMarkNsfw;

--- a/src/server/api/endpoints/users.ts
+++ b/src/server/api/endpoints/users.ts
@@ -65,6 +65,7 @@ export const meta = {
 
 export default define(meta, async (ps, me) => {
 	const query = Users.createQueryBuilder('user');
+	query.where('user.isExplorable = TRUE');
 
 	switch (ps.state) {
 		case 'admin': query.where('user.isAdmin = TRUE'); break;

--- a/src/server/api/endpoints/users/recommendation.ts
+++ b/src/server/api/endpoints/users/recommendation.ts
@@ -42,6 +42,7 @@ export const meta = {
 export default define(meta, async (ps, me) => {
 	const query = Users.createQueryBuilder('user')
 		.where('user.isLocked = FALSE')
+		.andWhere('user.isExplorable = TRUE')
 		.andWhere('user.host IS NULL')
 		.andWhere('user.updatedAt >= :date', { date: new Date(Date.now() - ms('7days')) })
 		.andWhere('user.id != :meId', { meId: me.id })

--- a/src/services/create-system-user.ts
+++ b/src/services/create-system-user.ts
@@ -41,6 +41,7 @@ export async function createSystemUser(username: string) {
 			token: secret,
 			isAdmin: false,
 			isLocked: true,
+			isExplorable: false,
 			isBot: true,
 		}).then(x => transactionalEntityManager.findOneOrFail(User, x.identifiers[0]));
 


### PR DESCRIPTION
めいすきーとv12以降、Mastodonにはアカウントの発見性についての設定があり連合するのだけども、v11にはまだその機能がないので、v12からバックポート、プライバシー強化